### PR TITLE
Update babel-core/register to babel-register

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,16 +14,17 @@
   },
   "homepage": "https://github.com/gaearon/babel-plugin-react-transform#readme",
   "devDependencies": {
-    "babel-cli": "^6.1.1",
-    "babel-core": "^6.0.0",
-    "babel-preset-es2015": "^6.0.15",
+    "babel-cli": "^6.1.18",
+    "babel-core": "^6.1.21",
+    "babel-register": "^6.1.18",
+    "babel-preset-es2015": "^6.1.18",
     "mocha": "^2.2.5",
     "rimraf": "^2.4.3"
   },
   "scripts": {
     "clean": "rimraf lib",
     "build": "babel src --out-dir lib --copy-files",
-    "test": "mocha --compilers js:babel-core/register",
+    "test": "mocha --compilers js:babel-register",
     "test:watch": "npm run test -- --watch",
     "prepublish": "npm run clean && npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib --copy-files",
+    "build": "babel src --out-dir lib",
     "test": "mocha --compilers js:babel-register",
     "test:watch": "npm run test -- --watch",
     "prepublish": "npm run clean && npm run build"


### PR DESCRIPTION
- Remove [deprecated](https://github.com/babel/babel/blob/master/packages/babel-core/register.js) `babel-core/register`, replace with `babel-register` package
- Updates some deps: `babel-cli`, `babel-core`, and `babel-preset-es2015`
- Updates mocha's `npm test` script to register compiler using new `babel-register`
- Removes unnecessary `--copy-files` flag from build script
